### PR TITLE
Spring boot actuator for sync repository implemented

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,6 +15,10 @@ reconf-spring/.classpath
 reconf-spring/.project
 reconf-spring/.springBeans
 target/*
+reconf-spring-boot-actuator/.settings/*
+reconf-spring-boot-actuator/target/*
+reconf-spring-boot-actuator/.classpath
+reconf-spring-boot-actuator/.project
 **/*.iml
 **/.idea/**
 reconf-servlet/.settings/org.eclipse.core.resources.prefs

--- a/pom.xml
+++ b/pom.xml
@@ -273,6 +273,7 @@
         <module>reconf-infra</module>
         <module>reconf-client</module>
         <module>reconf-spring</module>
+        <module>reconf-spring-boot-actuator</module>
         <module>reconf-servlet</module>
     </modules>
 </project>

--- a/reconf-spring-boot-actuator/pom.xml
+++ b/reconf-spring-boot-actuator/pom.xml
@@ -29,5 +29,11 @@
             <version>[1.3.2-RELEASE,)</version>
             <scope>provided</scope>
         </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-configuration-processor</artifactId>
+            <version>[1.3.2-RELEASE,)</version>
+            <optional>true</optional>
+        </dependency>
     </dependencies>
 </project>

--- a/reconf-spring-boot-actuator/pom.xml
+++ b/reconf-spring-boot-actuator/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <parent>
+        <artifactId>reconf-parent</artifactId>
+        <groupId>org.blocks4j.reconf</groupId>
+        <version>3.0.6-SNAPSHOT</version>
+    </parent>
+    <modelVersion>4.0.0</modelVersion>
+
+    <artifactId>reconf-spring-boot-actuator</artifactId>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.blocks4j.reconf</groupId>
+            <artifactId>reconf-client</artifactId>
+            <version>${project.parent.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-actuator</artifactId>
+            <version>[1.3.2-RELEASE,)</version>
+            <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-web</artifactId>
+            <version>[1.3.2-RELEASE,)</version>
+            <scope>provided</scope>
+        </dependency>
+    </dependencies>
+</project>

--- a/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfActuatorAutoConfiguration.java
+++ b/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfActuatorAutoConfiguration.java
@@ -1,0 +1,21 @@
+package org.blocks4j.reconf.spring.boot.actuator;
+
+import org.springframework.boot.actuate.condition.ConditionalOnEnabledEndpoint;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class ReconfActuatorAutoConfiguration {
+
+    @Bean
+    public ReconfSyncEndpoint reconfListEndpoint() {
+        return new ReconfSyncEndpoint();
+    }
+
+    @Bean
+    @ConditionalOnEnabledEndpoint(ReconfSyncEndpoint.RECONF_SYNC_ENDPOINT_ID)
+    public ReconfSyncMvcEndpoint reconfMvcEndpoint() {
+        return new ReconfSyncMvcEndpoint(this.reconfListEndpoint());
+    }
+
+}

--- a/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfActuatorAutoConfiguration.java
+++ b/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfActuatorAutoConfiguration.java
@@ -8,14 +8,14 @@ import org.springframework.context.annotation.Configuration;
 public class ReconfActuatorAutoConfiguration {
 
     @Bean
-    public ReconfSyncEndpoint reconfListEndpoint() {
+    public ReconfSyncEndpoint reconfSyncEndpoint() {
         return new ReconfSyncEndpoint();
     }
 
     @Bean
     @ConditionalOnEnabledEndpoint(ReconfSyncEndpoint.RECONF_SYNC_ENDPOINT_ID)
     public ReconfSyncMvcEndpoint reconfMvcEndpoint() {
-        return new ReconfSyncMvcEndpoint(this.reconfListEndpoint());
+        return new ReconfSyncMvcEndpoint(this.reconfSyncEndpoint());
     }
 
 }

--- a/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfSyncEndpoint.java
+++ b/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfSyncEndpoint.java
@@ -14,7 +14,7 @@ public class ReconfSyncEndpoint extends AbstractEndpoint<String> {
 
     private static final String RESULT_TEMPLATE = "{ \"repository\" : \"%s\", \"success\" : \"%s\" }";
 
-    public static final String RECONF_SYNC_ENDPOINT_ID = "_reconf_sync";
+    public static final String RECONF_SYNC_ENDPOINT_ID = "reconf_sync";
 
     public ReconfSyncEndpoint() {
         super(RECONF_SYNC_ENDPOINT_ID);

--- a/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfSyncEndpoint.java
+++ b/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfSyncEndpoint.java
@@ -1,0 +1,38 @@
+package org.blocks4j.reconf.spring.boot.actuator;
+
+import org.apache.commons.lang3.StringUtils;
+import org.blocks4j.reconf.client.setup.Environment;
+import org.blocks4j.reconf.client.setup.SyncResult;
+import org.springframework.boot.actuate.endpoint.AbstractEndpoint;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@ConfigurationProperties(prefix = "endpoints.reconf.sync", ignoreUnknownFields = true)
+public class ReconfSyncEndpoint extends AbstractEndpoint<String> {
+
+    private static final String RESULT_TEMPLATE = "{ \"repository\" : \"%s\", \"success\" : \"%s\" }";
+
+    public static final String RECONF_SYNC_ENDPOINT_ID = "_reconf_sync";
+
+    public ReconfSyncEndpoint() {
+        super(RECONF_SYNC_ENDPOINT_ID);
+    }
+
+    @Override
+    public String invoke() {
+        List<SyncResult> result = Environment.syncActiveConfigurationRepositoryUpdaters();
+
+        List<String> syncResultMessage = new ArrayList<String>();
+        for (SyncResult syncResult : result) {
+            if (syncResult == null) {
+                continue;
+            }
+            syncResultMessage.add(String.format(RESULT_TEMPLATE, syncResult.getName(), syncResult.getThrowable() == null));
+        }
+
+        return StringUtils.join(syncResultMessage, ", ");
+    }
+
+}

--- a/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfSyncMvcEndpoint.java
+++ b/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfSyncMvcEndpoint.java
@@ -35,7 +35,7 @@ public class ReconfSyncMvcEndpoint extends AbstractEndpointMvcAdapter<ReconfSync
     }
 
     private String getDefaultPath() {
-        return this.getDelegate().getId().replaceAll("_", "/");
+        return "/" + this.getDelegate().getId().replaceAll("_", "/");
     }
 
     @Override

--- a/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfSyncMvcEndpoint.java
+++ b/reconf-spring-boot-actuator/src/main/java/org/blocks4j/reconf/spring/boot/actuator/ReconfSyncMvcEndpoint.java
@@ -1,0 +1,52 @@
+package org.blocks4j.reconf.spring.boot.actuator;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.actuate.endpoint.mvc.AbstractEndpointMvcAdapter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.http.MediaType;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.ResponseBody;
+
+@ConfigurationProperties(prefix = "endpoints.reconf.sync", ignoreUnknownFields = true)
+public class ReconfSyncMvcEndpoint extends AbstractEndpointMvcAdapter<ReconfSyncEndpoint> {
+
+    private static final String BODY_TEMPLATE = "{ \"operation\" : \"%s\", \"result\" : [ %s ] }";
+
+    private String path;
+
+    @Autowired
+    public ReconfSyncMvcEndpoint(ReconfSyncEndpoint delegate) {
+        super(delegate);
+    }
+
+    @RequestMapping(produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    public Object sync() {
+        if (!getDelegate().isEnabled()) {
+            return getDisabledResponse();
+        }
+
+        return String.format(BODY_TEMPLATE, "sync", this.getDelegate().invoke());
+    }
+
+    @Override
+    public String getPath() {
+        return (this.path != null ? this.path : this.getDefaultPath());
+    }
+
+    private String getDefaultPath() {
+        return this.getDelegate().getId().replaceAll("_", "/");
+    }
+
+    @Override
+    public void setPath(String path) {
+        while (path.endsWith("/")) {
+            path = path.substring(0, path.length() - 1);
+        }
+        if (!path.startsWith("/")) {
+            path = "/reconf/" + path;
+        }
+
+        this.path = path;
+    }
+}

--- a/reconf-spring-boot-actuator/src/main/resources/META-INF/spring.factories
+++ b/reconf-spring-boot-actuator/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.actuate.autoconfigure.ManagementContextConfiguration=\
+org.blocks4j.reconf.spring.boot.actuator.ReconfActuatorAutoConfiguration


### PR DESCRIPTION
It is an alternative way to configure a managing interface for reconf client using spring boot actuators.
I created a new endpoint called "reconf.sync" (default path is "/reconf/sync").

best regards,
André Souza
